### PR TITLE
Use mkdirp to create temp directories for scoped packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var path = require('path');
 var os = require('os');
 var https = require('https');
 var { exec } = require('child_process');
+var mkdirp = require('mkdirp');
 
 var registry = 'https://registry.npmjs.org/'
 var localIPFSgateway = 'http://localhost:8080/'
@@ -72,6 +73,7 @@ function processDependency(key, value, cb) {
     var tarball = tmpDir+'/'+key+'-'+value.version+'.tgz'
 
     // download the tarball to ROOT
+    mkdirp.sync(path.dirname(tarball))
     downloadTarball(value.resolved, tarball, function() {
       // ipfs add tarball
       exec('ipfs add --quiet '+tarball, (err, stdout, stderr) => {

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ var path = require('path');
 var os = require('os');
 var https = require('https');
 var { exec } = require('child_process');
-var mkdirp = require('mkdirp');
 
 var registry = 'https://registry.npmjs.org/'
 var localIPFSgateway = 'http://localhost:8080/'
@@ -72,8 +71,15 @@ function processDependency(key, value, cb) {
   loadPackument(key, registry, function(packument) {
     var tarball = tmpDir+'/'+key+'-'+value.version+'.tgz'
 
+    const matchScoped = key.match(/^(@[^\/]+)\//)
+    if (matchScoped) {
+      const scopeDir = path.join(tmpDir, matchScoped[1])
+      if (!fs.existsSync(scopeDir)) {
+        fs.mkdirSync(scopeDir)
+      }
+    }
+
     // download the tarball to ROOT
-    mkdirp.sync(path.dirname(tarball))
     downloadTarball(value.resolved, tarball, function() {
       // ipfs add tarball
       exec('ipfs add --quiet '+tarball, (err, stdout, stderr) => {

--- a/package.json
+++ b/package.json
@@ -5,5 +5,8 @@
   "main": "index.js",
   "author": "Andrew Nesbitt",
   "license": "MIT",
-  "bin": "./index.js"
+  "bin": "./index.js",
+  "dependencies": {
+    "mkdirp": "^0.5.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,5 @@
   "main": "index.js",
   "author": "Andrew Nesbitt",
   "license": "MIT",
-  "bin": "./index.js",
-  "dependencies": {
-    "mkdirp": "^0.5.1"
-  }
+  "bin": "./index.js"
 }


### PR DESCRIPTION
It needs to create directories before downloading for scoped packages,
eg.

  @types/estree  (needed by jimpick/protocol-words)